### PR TITLE
Init image inpainting

### DIFF
--- a/image_to_image.py
+++ b/image_to_image.py
@@ -1,0 +1,161 @@
+import inspect
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+
+import PIL
+from diffusers import AutoencoderKL, DDIMScheduler, DiffusionPipeline, PNDMScheduler, UNet2DConditionModel
+from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
+from tqdm.auto import tqdm
+from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+
+
+def preprocess(image):
+    w, h = image.size
+    w, h = map(lambda x: x - x % 32, (w, h))  # resize to integer multiple of 32
+    image = image.resize((w, h), resample=PIL.Image.LANCZOS)
+    image = np.array(image).astype(np.float32) / 255.0
+    image = image[None].transpose(0, 3, 1, 2)
+    image = torch.from_numpy(image)
+    return 2.0 * image - 1.0
+
+
+class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
+    def __init__(
+        self,
+        vae: AutoencoderKL,
+        text_encoder: CLIPTextModel,
+        tokenizer: CLIPTokenizer,
+        unet: UNet2DConditionModel,
+        scheduler: Union[DDIMScheduler, PNDMScheduler],
+        safety_checker: StableDiffusionSafetyChecker,
+        feature_extractor: CLIPFeatureExtractor,
+    ):
+        super().__init__()
+        scheduler = scheduler.set_format("pt")
+        self.register_modules(
+            vae=vae,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            unet=unet,
+            scheduler=scheduler,
+            safety_checker=safety_checker,
+            feature_extractor=feature_extractor,
+        )
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        prompt: Union[str, List[str]],
+        init_image: torch.FloatTensor,
+        strength: float = 0.8,
+        num_inference_steps: Optional[int] = 50,
+        guidance_scale: Optional[float] = 7.5,
+        eta: Optional[float] = 0.0,
+        generator: Optional[torch.Generator] = None,
+        output_type: Optional[str] = "pil",
+    ):
+
+        if isinstance(prompt, str):
+            batch_size = 1
+        elif isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
+
+        # set timesteps
+        accepts_offset = "offset" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
+        extra_set_kwargs = {}
+        offset = 0
+        if accepts_offset:
+            offset = 1
+            extra_set_kwargs["offset"] = 1
+
+        self.scheduler.set_timesteps(num_inference_steps, **extra_set_kwargs)
+
+        # encode the init image into latents and scale the latents
+        init_latents = self.vae.encode(init_image.to(self.device)).sample()
+        init_latents = 0.18215 * init_latents
+
+        # prepare init_latents noise to latents
+        init_latents = torch.cat([init_latents] * batch_size)
+
+        # get the original timestep using init_timestep
+        init_timestep = int(num_inference_steps * strength) + offset
+        init_timestep = min(init_timestep, num_inference_steps)
+        timesteps = self.scheduler.timesteps[-init_timestep]
+        timesteps = torch.tensor([timesteps] * batch_size, dtype=torch.long, device=self.device)
+
+        # add noise to latents using the timesteps
+        noise = torch.randn(init_latents.shape, generator=generator, device=self.device)
+        init_latents = self.scheduler.add_noise(init_latents, noise, timesteps)
+
+        # get prompt text embeddings
+        text_input = self.tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=self.tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_embeddings = self.text_encoder(text_input.input_ids.to(self.device))[0]
+
+        # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
+        # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
+        # corresponds to doing no classifier free guidance.
+        do_classifier_free_guidance = guidance_scale > 1.0
+        # get unconditional embeddings for classifier free guidance
+        if do_classifier_free_guidance:
+            max_length = text_input.input_ids.shape[-1]
+            uncond_input = self.tokenizer(
+                [""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt"
+            )
+            uncond_embeddings = self.text_encoder(uncond_input.input_ids.to(self.device))[0]
+
+            # For classifier free guidance, we need to do two forward passes.
+            # Here we concatenate the unconditional and text embeddings into a single batch
+            # to avoid doing two forward passes
+            text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+
+        # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature
+        # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.
+        # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502
+        # and should be between [0, 1]
+        accepts_eta = "eta" in set(inspect.signature(self.scheduler.step).parameters.keys())
+        extra_step_kwargs = {}
+        if accepts_eta:
+            extra_step_kwargs["eta"] = eta
+
+        latents = init_latents
+        t_start = max(num_inference_steps - init_timestep + offset, 0)
+        for i, t in tqdm(enumerate(self.scheduler.timesteps[t_start:])):
+            # expand the latents if we are doing classifier free guidance
+            latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+
+            # predict the noise residual
+            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings)["sample"]
+
+            # perform guidance
+            if do_classifier_free_guidance:
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+
+            # compute the previous noisy sample x_t -> x_t-1
+            latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)["prev_sample"]
+
+        # scale and decode the image latents with vae
+        latents = 1 / 0.18215 * latents
+        image = self.vae.decode(latents)
+
+        image = (image / 2 + 0.5).clamp(0, 1)
+        image = image.cpu().permute(0, 2, 3, 1).numpy()
+
+        # run safety checker
+        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
+        image, has_nsfw_concept = self.safety_checker(images=image, clip_input=safety_cheker_input.pixel_values)
+
+        if output_type == "pil":
+            image = self.numpy_to_pil(image)
+
+        return {"sample": image, "nsfw_content_detected": has_nsfw_concept}

--- a/image_to_image.py
+++ b/image_to_image.py
@@ -1,27 +1,18 @@
 import inspect
 from typing import List, Optional, Union
 
-import numpy as np
 import torch
 
-import PIL
 from diffusers import AutoencoderKL, DDIMScheduler, DiffusionPipeline, PNDMScheduler, UNet2DConditionModel
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from tqdm.auto import tqdm
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 
 
-def preprocess(image):
-    w, h = image.size
-    w, h = map(lambda x: x - x % 32, (w, h))  # resize to integer multiple of 32
-    image = image.resize((w, h), resample=PIL.Image.LANCZOS)
-    image = np.array(image).astype(np.float32) / 255.0
-    image = image[None].transpose(0, 3, 1, 2)
-    image = torch.from_numpy(image)
-    return 2.0 * image - 1.0
-
-
 class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
+    """
+    From https://raw.githubusercontent.com/huggingface/diffusers/a311826f1a8fdbf1265ac86b157990a37df8e3b7/examples/inference/image_to_image.py
+    """
     def __init__(
         self,
         vae: AutoencoderKL,

--- a/image_to_image.py
+++ b/image_to_image.py
@@ -1,17 +1,43 @@
 import inspect
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
+import numpy as np
 import torch
 
-from diffusers import AutoencoderKL, DDIMScheduler, DiffusionPipeline, PNDMScheduler, UNet2DConditionModel
+from PIL import Image
+from diffusers import (
+    AutoencoderKL,
+    DDIMScheduler,
+    DiffusionPipeline,
+    PNDMScheduler,
+    UNet2DConditionModel,
+)
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from tqdm.auto import tqdm
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 
 
+def preprocess_init_image(image: Image, width: int, height: int):
+    image = image.resize((width, height), resample=Image.LANCZOS)
+    image = np.array(image).astype(np.float32) / 255.0
+    image = image[None].transpose(0, 3, 1, 2)
+    image = torch.from_numpy(image)
+    return 2.0 * image - 1.0
+
+
+def preprocess_mask(mask: Image, width: int, height: int):
+    mask = mask.convert("L")
+    mask = mask.resize((width // 8, height // 8), resample=Image.LANCZOS)
+    mask = np.array(mask).astype(np.float32) / 255.0
+    mask = np.tile(mask, (4, 1, 1))
+    mask = mask[None].transpose(0, 1, 2, 3)  # what does this step do?
+    mask = torch.from_numpy(mask)
+    return mask
+
+
 class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
     """
-    From https://raw.githubusercontent.com/huggingface/diffusers/a311826f1a8fdbf1265ac86b157990a37df8e3b7/examples/inference/image_to_image.py
+    From https://github.com/huggingface/diffusers/pull/241
     """
     def __init__(
         self,
@@ -39,24 +65,42 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
     def __call__(
         self,
         prompt: Union[str, List[str]],
-        init_image: torch.FloatTensor,
-        strength: float = 0.8,
-        num_inference_steps: Optional[int] = 50,
-        guidance_scale: Optional[float] = 7.5,
-        eta: Optional[float] = 0.0,
+        init_image: Optional[torch.FloatTensor],
+        mask: Optional[torch.FloatTensor],
+        width: int,
+        height: int,
+        prompt_strength: float = 0.8,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 7.5,
+        eta: float = 0.0,
         generator: Optional[torch.Generator] = None,
-        output_type: Optional[str] = "pil",
-    ):
-
+    ) -> Image:
         if isinstance(prompt, str):
             batch_size = 1
         elif isinstance(prompt, list):
             batch_size = len(prompt)
         else:
-            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
+            raise ValueError(
+                f"`prompt` has to be of type `str` or `list` but is {type(prompt)}"
+            )
+
+        if prompt_strength < 0 or prompt_strength > 1:
+            raise ValueError(
+                f"The value of prompt_strength should in [0.0, 1.0] but is {prompt_strength}"
+            )
+
+        if mask is not None and init_image is None:
+            raise ValueError(
+                "If mask is defined, then init_image also needs to be defined"
+            )
+
+        if width % 8 != 0 or height % 8 != 0:
+            raise ValueError("Width and height must both be divisible by 8")
 
         # set timesteps
-        accepts_offset = "offset" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
+        accepts_offset = "offset" in set(
+            inspect.signature(self.scheduler.set_timesteps).parameters.keys()
+        )
         extra_set_kwargs = {}
         offset = 0
         if accepts_offset:
@@ -65,23 +109,117 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
 
         self.scheduler.set_timesteps(num_inference_steps, **extra_set_kwargs)
 
+        if init_image is not None:
+            init_latents_orig, latents, init_timestep = self.latents_from_init_image(
+                init_image, prompt_strength, offset, num_inference_steps, batch_size, generator
+            )
+        else:
+            latents = torch.randn(
+                (batch_size, self.unet.in_channels, height // 8, width // 8),
+                generator=generator,
+                device=self.device,
+            )
+            init_timestep = num_inference_steps
+
+        do_classifier_free_guidance = guidance_scale > 1.0
+        text_embeddings = self.embed_text(
+            prompt, do_classifier_free_guidance, batch_size
+        )
+
+        # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature
+        # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.
+        # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502
+        # and should be between [0, 1]
+        accepts_eta = "eta" in set(
+            inspect.signature(self.scheduler.step).parameters.keys()
+        )
+        extra_step_kwargs = {}
+        if accepts_eta:
+            extra_step_kwargs["eta"] = eta
+
+        t_start = max(num_inference_steps - init_timestep + offset, 0)
+        for i, t in tqdm(enumerate(self.scheduler.timesteps[t_start:])):
+            # expand the latents if we are doing classifier free guidance
+            latent_model_input = (
+                torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+            )
+
+            # predict the noise residual
+            noise_pred = self.unet(
+                latent_model_input, t, encoder_hidden_states=text_embeddings
+            )["sample"]
+
+            # perform guidance
+            if do_classifier_free_guidance:
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond + guidance_scale * (
+                    noise_pred_text - noise_pred_uncond
+                )
+
+            # compute the previous noisy sample x_t -> x_t-1
+            latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)[
+                "prev_sample"
+            ]
+
+            if mask is not None:
+                latents = init_latents_orig * mask + latents * (1 - mask)
+
+        # scale and decode the image latents with vae
+        latents = 1 / 0.18215 * latents
+        image = self.vae.decode(latents)
+
+        image = (image / 2 + 0.5).clamp(0, 1)
+        image = image.cpu().permute(0, 2, 3, 1).numpy()
+
+        # run safety checker
+        safety_cheker_input = self.feature_extractor(
+            self.numpy_to_pil(image), return_tensors="pt"
+        ).to(self.device)
+        image, has_nsfw_concept = self.safety_checker(
+            images=image, clip_input=safety_cheker_input.pixel_values
+        )
+
+        image = self.numpy_to_pil(image)
+
+        return {"sample": image, "nsfw_content_detected": has_nsfw_concept}
+
+    def latents_from_init_image(
+        self,
+        init_image: torch.FloatTensor,
+        prompt_strength: float,
+        offset: int,
+        num_inference_steps: int,
+        batch_size: int,
+        generator: Optional[torch.Generator],
+    ) -> Tuple[torch.FloatTensor, torch.FloatTensor, int]:
         # encode the init image into latents and scale the latents
         init_latents = self.vae.encode(init_image.to(self.device)).sample()
         init_latents = 0.18215 * init_latents
+        init_latents_orig = init_latents
 
         # prepare init_latents noise to latents
         init_latents = torch.cat([init_latents] * batch_size)
 
         # get the original timestep using init_timestep
-        init_timestep = int(num_inference_steps * strength) + offset
+        init_timestep = int(num_inference_steps * prompt_strength) + offset
         init_timestep = min(init_timestep, num_inference_steps)
         timesteps = self.scheduler.timesteps[-init_timestep]
-        timesteps = torch.tensor([timesteps] * batch_size, dtype=torch.long, device=self.device)
+        timesteps = torch.tensor(
+            [timesteps] * batch_size, dtype=torch.long, device=self.device
+        )
 
         # add noise to latents using the timesteps
         noise = torch.randn(init_latents.shape, generator=generator, device=self.device)
         init_latents = self.scheduler.add_noise(init_latents, noise, timesteps)
 
+        return init_latents_orig, init_latents, init_timestep
+
+    def embed_text(
+        self,
+        prompt: Union[str, List[str]],
+        do_classifier_free_guidance: bool,
+        batch_size: int,
+    ) -> torch.FloatTensor:
         # get prompt text embeddings
         text_input = self.tokenizer(
             prompt,
@@ -95,58 +233,22 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0
         # get unconditional embeddings for classifier free guidance
         if do_classifier_free_guidance:
             max_length = text_input.input_ids.shape[-1]
             uncond_input = self.tokenizer(
-                [""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt"
+                [""] * batch_size,
+                padding="max_length",
+                max_length=max_length,
+                return_tensors="pt",
             )
-            uncond_embeddings = self.text_encoder(uncond_input.input_ids.to(self.device))[0]
+            uncond_embeddings = self.text_encoder(
+                uncond_input.input_ids.to(self.device)
+            )[0]
 
             # For classifier free guidance, we need to do two forward passes.
             # Here we concatenate the unconditional and text embeddings into a single batch
             # to avoid doing two forward passes
             text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
 
-        # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature
-        # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.
-        # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502
-        # and should be between [0, 1]
-        accepts_eta = "eta" in set(inspect.signature(self.scheduler.step).parameters.keys())
-        extra_step_kwargs = {}
-        if accepts_eta:
-            extra_step_kwargs["eta"] = eta
-
-        latents = init_latents
-        t_start = max(num_inference_steps - init_timestep + offset, 0)
-        for i, t in tqdm(enumerate(self.scheduler.timesteps[t_start:])):
-            # expand the latents if we are doing classifier free guidance
-            latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
-
-            # predict the noise residual
-            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings)["sample"]
-
-            # perform guidance
-            if do_classifier_free_guidance:
-                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
-                noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
-
-            # compute the previous noisy sample x_t -> x_t-1
-            latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)["prev_sample"]
-
-        # scale and decode the image latents with vae
-        latents = 1 / 0.18215 * latents
-        image = self.vae.decode(latents)
-
-        image = (image / 2 + 0.5).clamp(0, 1)
-        image = image.cpu().permute(0, 2, 3, 1).numpy()
-
-        # run safety checker
-        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
-        image, has_nsfw_concept = self.safety_checker(images=image, clip_input=safety_cheker_input.pixel_values)
-
-        if output_type == "pil":
-            image = self.numpy_to_pil(image)
-
-        return {"sample": image, "nsfw_content_detected": has_nsfw_concept}
+        return text_embeddings

--- a/predict.py
+++ b/predict.py
@@ -1,26 +1,37 @@
 import os
 from typing import List
 
+import numpy as np
 import torch
 from cog import BasePredictor, Input, Path
 from diffusers import PNDMScheduler
 from PIL import Image
 
-from image_to_image import StableDiffusionImg2ImgPipeline, preprocess
+from image_to_image import StableDiffusionImg2ImgPipeline
+
+MODEL_CACHE = "diffusers-cache"
+
+def preprocess(image):
+    w, h = image.size
+    w, h = map(lambda x: x - x % 32, (w, h))  # resize to integer multiple of 32
+    image = image.resize((w, h), resample=Image.LANCZOS)
+    image = np.array(image).astype(np.float32) / 255.0
+    image = image[None].transpose(0, 3, 1, 2)
+    image = torch.from_numpy(image)
+    return 2.0 * image - 1.0
 
 
 class Predictor(BasePredictor):
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""
         print("Loading pipeline...")
-        self.model_cache = "model_cache"
+        self.log_dir = Path("/tmp/cog-stable-diffusion")
+        self.log_dir.mkdir(exist_ok=True)
 
-        scheduler = PNDMScheduler(
-            beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear"
-        )
+        scheduler = PNDMScheduler()
         self.pipe = StableDiffusionImg2ImgPipeline.from_pretrained(
             "CompVis/stable-diffusion-v1-4",
-            cache_dir="diffusers-cache",
+            cache_dir=MODEL_CACHE,
             scheduler=scheduler,
             revision="fp16",
             torch_dtype=torch.float16,
@@ -31,16 +42,28 @@ class Predictor(BasePredictor):
     @torch.cuda.amp.autocast()
     def predict(
         self,
-        prompt: str = Input(description="Input prompt"),
+        prompt: str = Input(description="Input prompt", default=""),
         init_image: Path = Input(
             description="Inital image to generate variations of.", default=None
         ),
         strength: float = Input(
             description="Strength for noising/unnoising. 1.0 corresponds to full destruction of information in init image.",
             default=0.8,
+            ge=0.0,
+            le=1.0,
+        ),
+        width: int = Input(
+            description="Width of output image",
+            default=512,
+            choices=[256, 384, 512, 640, 768, 896, 1024],
+        ),
+        height: int = Input(
+            description="Height of output image",
+            default=512,
+            choices=[256, 384, 512, 640, 768, 896, 1024],
         ),
         num_outputs: int = Input(
-            description="Number of images to output", choices=[1, 4, 16], default=4
+            description="Number of images to output", choices=[1, 4, 16], default=1
         ),
         num_inference_steps: int = Input(
             description="Number of denoising steps", ge=1, le=500, default=100
@@ -55,26 +78,41 @@ class Predictor(BasePredictor):
         """Run a single prediction on the model"""
         if seed is None:
             seed = int.from_bytes(os.urandom(2), "big")
+        generator = torch.Generator("cuda").manual_seed(seed)
         print(f"Using seed: {seed}")
 
-        init_image = Image.open(init_image).convert("RGB")
-        init_image = init_image.resize((512, 512))
-        init_image = preprocess(init_image)
-        generator = torch.Generator("cuda").manual_seed(seed)
+        if init_image is not None:
+            init_image = Image.open(init_image).convert("RGB")
+            init_image = preprocess(init_image)
+            width, height = init_image.shape[2], init_image.shape[3]
+        else:
+            init_image = torch.randn(
+                1,
+                3,
+                height,
+                width,
+                dtype=torch.float16,
+                generator=generator,
+                device="cuda",
+            )
+            strength = 1.0  # disable noising
+
+        print(f"Using resolution of {width}x{height} for generation dimensions.")
+        prompt = [prompt] * num_outputs
+
         output = self.pipe(
+            prompt=prompt,
             init_image=init_image,
-            prompt=[prompt] * num_outputs if prompt is not None else None,
+            strength=strength,
+            num_inference_steps=num_inference_steps,
             guidance_scale=guidance_scale,
             generator=generator,
-            num_inference_steps=num_inference_steps,
-            strength=strength,
+            output_type="pil",
         )
-        if any(output["nsfw_content_detected"]):
-            raise Exception("NSFW content detected, please try a different prompt")
 
         output_paths = []
         for i, sample in enumerate(output["sample"]):
-            output_path = f"/tmp/out-{i}.png"
+            output_path = self.log_dir / f"out-{i:03d}.png"
             sample.save(output_path)
             output_paths.append(Path(output_path))
 

--- a/predict.py
+++ b/predict.py
@@ -52,7 +52,7 @@ class Predictor(BasePredictor):
             description="Inital image to generate variations of", default=None
         ),
         mask: Path = Input(
-            description="Black and white image to use as mask for inpainting over init_image. Black pixels are inpainted and white pixels are preserved",
+            description="Black and white image to use as mask for inpainting over init_image. Black pixels are inpainted and white pixels are preserved. Experimental feature, tends to work better with prompt strength of 0.5-0.7",
             default=None,
         ),
         prompt_strength: float = Input(


### PR DESCRIPTION
Builds on top of and supersedes https://github.com/replicate/cog-stable-diffusion/pull/1

This PR adds image-to-image generation and in-painting.

It also changes the sampler from LMS to PNDM, but doesn't have noticeable effects on outputs:
* https://replicate.com/p/4eeyrlckcfgirnlm5hrpja3i64 uses LMS
* https://replicate.com/p/hzucpslq4rg6zb3n7gp5r75aee uses PNDM

In-painting examples: https://replicate.com/andreasjansson/stable-diffusion-wip/examples

![](https://replicate.com/api/models/andreasjansson/stable-diffusion-wip/files/0cb97efb-8e76-4bd2-803b-4f3c60a37da0/out-0.png)