### PR TITLE
Add more image sizes and number of outputs

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -34,12 +34,12 @@ class Predictor(BasePredictor):
         prompt: str = Input(description="Input prompt", default=""),
         width: int = Input(
             description="Width of output image. Maximum size is 1024x768 or 768x1024 because of memory limits",
-            choices=[128, 256, 512, 768, 896, 1024],
+            choices=[128, 256, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
             default=512,
         ),
         height: int = Input(
             description="Height of output image. Maximum size is 1024x768 or 768x1024 because of memory limits",
-            choices=[128, 256, 512, 768, 896, 1024],
+            choices=[128, 256, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
             default=512,
         ),
         init_image: Path = Input(
@@ -56,7 +56,7 @@ class Predictor(BasePredictor):
         ),
         num_outputs: int = Input(
             description="Number of images to output. NSFW filter in enabled, so you may get fewer outputs than requested if flagged",
-            choices=[1, 4],
+            choices=[1, 2, 4, 9],
             default=1,
         ),
         num_inference_steps: int = Input(

--- a/predict.py
+++ b/predict.py
@@ -56,8 +56,9 @@ class Predictor(BasePredictor):
         ),
         num_outputs: int = Input(
             description="Number of images to output. NSFW filter in enabled, so you may get fewer outputs than requested if flagged",
-            choices=[1, 2, 4, 9],
-            default=1,
+            ge=1,
+            le=10,
+            default=1
         ),
         num_inference_steps: int = Input(
             description="Number of denoising steps", ge=1, le=500, default=50
@@ -79,7 +80,7 @@ class Predictor(BasePredictor):
             seed = int.from_bytes(os.urandom(2), "big")
         print(f"Using seed: {seed}")
 
-        if width == height == 1024:
+        if width * height > 786432:
             raise ValueError(
                 "Maximum size is 1024x768 or 768x1024 pixels, because of memory limits. Please select a lower width or height."
             )


### PR DESCRIPTION
I would REALLy love to be able to do 512x640, maybe some other ratios. No reason to limit people.

These are all the size options in 64bit increments allowed by official dreamstudio API.