### PR TITLE
Add multiple outputs

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -134,6 +134,7 @@ class Predictor(BasePredictor):
             guidance_scale=guidance_scale,
             generator=generator,
             num_inference_steps=num_inference_steps,
+            num_images_per_prompt=num_outputs,
             **extra_kwargs,
         )
 


### PR DESCRIPTION
This PR should enable multiple output images in https://replicate.com/stability-ai/stable-diffusion
Notice that using the web, you always get a single image, no matter how many "num_outputs" you've selected.

I've checked other repositories of yours so I think "num_images_per_prompt" is the argument missing, but should be great if you can test if before.





