### PR TITLE
Add new schedulers and negative prompt

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -3,9 +3,10 @@ build:
   cuda: "11.6.2"
   python_version: "3.10"
   python_packages:
-    - "diffusers==0.6.0"
+    - "diffusers==0.7.1"
     - "torch==1.12.1 --extra-index-url=https://download.pytorch.org/whl/cu116"
     - "ftfy==6.1.1"
     - "scipy==1.9.0"
     - "transformers==4.21.1"
+    - "accelerate==0.13.2"
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -132,6 +132,7 @@ class Predictor(BasePredictor):
         generator = torch.Generator("cuda").manual_seed(seed)
         output = pipe(
             prompt=[prompt] * num_outputs if prompt is not None else None,
+            negative_prompt=[negative_prompt] * num_outputs if negative_prompt is not None else None,
             width=width,
             height=height,
             guidance_scale=guidance_scale,

--- a/predict.py
+++ b/predict.py
@@ -166,9 +166,34 @@ class Predictor(BasePredictor):
 
 def make_scheduler(name):
     return {
-        "PNDM": PNDMScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler"),
-        "K-LMS": LMSDiscreteScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler"),
-        "DDIM": DDIMScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler"),
-        "K_EULER": EulerDiscreteScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler"),
-        "K_EULER_ANCESTRAL": EulerAncestralDiscreteScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler"),
+        "PNDM": PNDMScheduler.from_config(
+            "runwayml/stable-diffusion-v1-5",
+            cache_dir=MODEL_CACHE, 
+            local_files_only=True, 
+            subfolder="scheduler"
+        ),
+        "K-LMS": LMSDiscreteScheduler.from_config(
+            "runwayml/stable-diffusion-v1-5",
+            cache_dir=MODEL_CACHE,
+            local_files_only=True,
+            subfolder="scheduler"
+        ),
+        "DDIM": DDIMScheduler.from_config(
+            "runwayml/stable-diffusion-v1-5",
+            cache_dir=MODEL_CACHE,
+            local_files_only=True,
+            subfolder="scheduler"
+        ),
+        "K_EULER": EulerDiscreteScheduler.from_config(
+            "runwayml/stable-diffusion-v1-5",
+            cache_dir=MODEL_CACHE, 
+            local_files_only=True, 
+            subfolder="scheduler"
+        ),
+        "K_EULER_ANCESTRAL": EulerAncestralDiscreteScheduler.from_config(
+            "runwayml/stable-diffusion-v1-5",
+            cache_dir=MODEL_CACHE, 
+            local_files_only=True,
+            subfolder="scheduler"
+        ),
     }[name]


### PR DESCRIPTION
# What is this?

1. In this PR I've upgraded the `diffusers` library to the latest one - [v0.7.1](https://github.com/huggingface/diffusers/releases/tag/v0.7.1)
2. Added support for new param: `negative_prompt`
3. Added support for new schedulers: `EulerAncestralDiscreteScheduler`, `EulerDiscreteScheduler`

# Why?
With this PR I want to improve the current cog version for the model, so other community members can start using the latest custom schedulers and set up negative prompt.

# How did you test to ensure no regressions?
I've used [brev console](https://console.brev.dev/) for testing it.
<img width="523" alt="Screenshot 2022-11-04 at 21 31 39" src="https://user-images.githubusercontent.com/22455666/200068882-361b975f-6c33-41e1-b5aa-3214c7a02608.png">

# Testing results:
Below are my testing results with different schedulers with default settings and other custom input:

**prompt:**
_Ragdoll cat king wearing a golden crown, intricate, elegant, highly detailed, centered, digital painting, artstation, concept art, smooth, sharp focus, illustration, artgerm, Tomasz Alen Kopera, Peter Mohrbacher, donato giancola, Joseph Christian Leyendecker, WLOP, Boris Vallejo_

**seed:** _789_

<img width="830" alt="Screenshot 2022-11-04 at 21 25 25" src="https://user-images.githubusercontent.com/22455666/200069031-ef391047-4e45-448c-8984-62d6287dfdc1.png">

and with **negative prompt** _yellow color, cat, nose_ with `K_EULER_ANCESTRAL`:
<img width="503" alt="Screenshot 2022-11-04 at 21 35 55" src="https://user-images.githubusercontent.com/22455666/200069638-96b390e9-c68e-43b1-afc2-6b6c89925cbd.png">
