### PR TITLE
Add support for negative prompt

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -51,7 +51,7 @@ class Predictor(BasePredictor):
     def predict(
         self,
         prompt: str = Input(description="Input prompt", default=""),
-        negative_prompt: str = Input(description="Input negative prompt", default=""),
+        negative_prompt: str = Input(description="The prompt NOT to guide the image generation. Ignored when not using guidance", default=None),
         width: int = Input(
             description="Width of output image. Maximum size is 1024x768 or 768x1024 because of memory limits",
             choices=[128, 256, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],

--- a/predict.py
+++ b/predict.py
@@ -51,6 +51,7 @@ class Predictor(BasePredictor):
     def predict(
         self,
         prompt: str = Input(description="Input prompt", default=""),
+        negative_prompt: str = Input(description="Input negative prompt", default=""),
         width: int = Input(
             description="Width of output image. Maximum size is 1024x768 or 768x1024 because of memory limits",
             choices=[128, 256, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
@@ -129,6 +130,7 @@ class Predictor(BasePredictor):
         generator = torch.Generator("cuda").manual_seed(seed)
         output = pipe(
             prompt=[prompt] * num_outputs if prompt is not None else None,
+            negative_prompt=[negative_prompt] * num_outputs if negative_prompt is not None else None,
             width=width,
             height=height,
             guidance_scale=guidance_scale,


### PR DESCRIPTION
# What is this?
Added support for new param: `negative_prompt` (extracted this part from the [prev pr](https://github.com/replicate/cog-stable-diffusion/pull/43)).

# Why?
We have a lot of requests in the issues for negative prompt support, that's why I've created this PR.

# How did you test to ensure no regressions?
I've used [brev console](https://console.brev.dev/) for testing it.
<img width="523" alt="Screenshot 2022-11-04 at 21 31 39" src="https://user-images.githubusercontent.com/22455666/200068882-361b975f-6c33-41e1-b5aa-3214c7a02608.png">

# Testing results:
Below are my testing results from the [previous pr](https://github.com/replicate/cog-stable-diffusion/pull/43):

**prompt:**
_Ragdoll cat king wearing a golden crown, intricate, elegant, highly detailed, centered, digital painting, artstation, concept art, smooth, sharp focus, illustration, artgerm, Tomasz Alen Kopera, Peter Mohrbacher, donato giancola, Joseph Christian Leyendecker, WLOP, Boris Vallejo_

**seed:** _789_

<img width="830" alt="Screenshot 2022-11-04 at 21 25 25" src="https://user-images.githubusercontent.com/22455666/200069031-ef391047-4e45-448c-8984-62d6287dfdc1.png">

and with **negative prompt** _yellow color, cat, nose_ with `K_EULER_ANCESTRAL`:
<img width="503" alt="Screenshot 2022-11-04 at 21 35 55" src="https://user-images.githubusercontent.com/22455666/200069638-96b390e9-c68e-43b1-afc2-6b6c89925cbd.png">
