### PR TITLE
Remove index URL hack

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,10 +1,9 @@
 build:
   gpu: true
-  cuda: "11.6.2"
   python_version: "3.10"
   python_packages:
     - "diffusers==0.6.0"
-    - "torch==1.12.1 --extra-index-url=https://download.pytorch.org/whl/cu116"
+    - "torch==1.12.1"
     - "ftfy==6.1.1"
     - "scipy==1.9.0"
     - "transformers==4.21.1"


### PR DESCRIPTION
When https://github.com/replicate/cog/pull/812 is in, we don't need this any longer. We should go round and remove this anywhere we see it too – e.g. in https://github.com/replicate/dreambooth and https://github.com/replicate/dreambooth-template

cc @chenxwh 