### PR TITLE
Remove prompt_strength

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -59,10 +59,6 @@ class Predictor(BasePredictor):
             choices=[128, 256, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
             default=768,
         ),
-        prompt_strength: float = Input(
-            description="Prompt strength when using init image. 1.0 corresponds to full destruction of information in init image",
-            default=0.8,
-        ),
         num_outputs: int = Input(
             description="Number of images to output.",
             ge=1,


### PR DESCRIPTION
The `prompt_strength` parameter is never used, and it seems the [`StableDiffusionPipeline`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L409) doesn't need it anymore. As someone who was trying to optimize the parameters of the models for a specific task, it was confusing to find out that `prompt_strength` actually does nothing.