### PR TITLE
add Actions workflow to push model to Replicate 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: Release
 
-env:
-  model_name: zeke/stable-diffusion
-
+# This workflow is triggered manually from the GitHub website.
+# To run it, click the "Actions" tab on the repo page.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      model_name:
+        required: true
+        description: The name of the Replicate model to publish, in the format `username-or-org/modelname`.
 
 jobs:
   release:
@@ -43,4 +44,4 @@ jobs:
 
       - name: Push to Replicate
         run: |
-          cog push r8.im/${{ env.model_name }}
+          cog push r8.im/${{ inputs.model_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Push model to Replicate
 
 # This workflow is triggered manually from the GitHub website.
 # To run it, click the "Actions" tab on the repo page.
@@ -10,7 +10,7 @@ on:
         description: The name of the Replicate model to publish, in the format `username-or-org/modelname`.
 
 jobs:
-  release:
+  push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +28,7 @@ jobs:
         run: |
           curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
           
+      # This version of Cog adds support `cog run` on non-GPU environments like GitHub Actions' default runners
       - name: Install Cog v0.8.0-beta3
         run: |
           sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/download/v0.8.0-beta3/cog_Linux_x86_64
@@ -38,7 +39,7 @@ jobs:
           docker version
           cog --version
 
-      - name: Download weights
+      - name: Download model weights from HuggingFace
         run: |
           cog run script/download-weights
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,24 +18,15 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install Python dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Download weights
-        run: |
-          script/download-weights
-
       - name: Install Cog
         run: |
           sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
           sudo chmod +x /usr/local/bin/cog
 
+      - name: Download weights
+        run: |
+          cog run script/download-weights
+  
       - name: Log in to Replicate
         env:
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # - name: Free disk space
-      #   uses: jlumbroso/free-disk-space@main
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
           
+      - name: Print Docker and Cog version info
+        run: |
+          docker version
+          cog --version
+
       - name: Download weights
         run: |
           cog run script/download-weights

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Install Cog and NVIDIA drivers
+      - name: Install Cog v0.8.0-beta3
         run: |
-          curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
-          
-      - name: Print Docker and Cog version info
+          sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/download/v0.8.0-beta3/cog_Linux_x86_64
+          sudo chmod +x /usr/local/bin/cog
+          cog --version
+
+      - name: Install nvidia-docker
         run: |
           docker version
-          cog --version
+
+          pushd /tmp
+          mkdir install-nvidia-docker
+          cd install-nvidia-docker
+
+          distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+              && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+              && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+                  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+                  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+          sudo apt-get update
+          apt-get download nvidia-container-toolkit-base nvidia-container-toolkit libnvidia-container-tools libnvidia-container1 nvidia-docker2
+          sudo dpkg  --ignore-depends=docker-ce -i *.deb
+
+          popd
+
+          # restart docker
+          sudo rm -f /var/run/docker.pid
+          sudo killall -9 dockerd
+          sudo bash -c "nohup dockerd &>/var/log/dockerd.log &"
 
       - name: Download weights
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Install Cog and NVIDIA drivers
         run: |
           curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
+          tool-cache: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
 
-      - name: Install Cog
+      - name: Install Cog and NVIDIA drivers
         run: |
-          sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
-          sudo chmod +x /usr/local/bin/cog
-
+          curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
+          
       - name: Download weights
         run: |
           cog run script/download-weights

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+      # - name: Free disk space
+      #   uses: jlumbroso/free-disk-space@main
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,35 +21,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Install Cog and NVIDIA drivers
+        run: |
+          curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
+          
       - name: Install Cog v0.8.0-beta3
         run: |
           sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/download/v0.8.0-beta3/cog_Linux_x86_64
           sudo chmod +x /usr/local/bin/cog
-          cog --version
-
-      - name: Install nvidia-docker
+          
+      - name: Print Docker and Cog version info
         run: |
           docker version
-
-          pushd /tmp
-          mkdir install-nvidia-docker
-          cd install-nvidia-docker
-
-          distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-              && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-              && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-                  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-                  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-          sudo apt-get update
-          apt-get download nvidia-container-toolkit-base nvidia-container-toolkit libnvidia-container-tools libnvidia-container1 nvidia-docker2
-          sudo dpkg  --ignore-depends=docker-ce -i *.deb
-
-          popd
-
-          # restart docker
-          sudo rm -f /var/run/docker.pid
-          sudo killall -9 dockerd
-          sudo bash -c "nohup dockerd &>/var/log/dockerd.log &"
+          cog --version
 
       - name: Download weights
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+env:
+  model_name: zeke/stable-diffusion
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Download weights
+        run: |
+          script/download-weights
+
+      - name: Install Cog
+        run: |
+          sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/latest/download/cog_`uname -s`_`uname -m`
+          sudo chmod +x /usr/local/bin/cog
+
+      - name: Log in to Replicate
+        env:
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+        run: |
+          echo $REPLICATE_API_TOKEN | cog login --token-stdin
+
+      - name: Push to Replicate
+        run: |
+          cog push r8.im/${{ env.model_name }}

--- a/cog.yaml
+++ b/cog.yaml
@@ -2,12 +2,6 @@ build:
   gpu: true
   cuda: "11.6"
   python_version: "3.10"
-  python_packages:
-    - "diffusers==0.11.1"
-    - "torch==1.13.0"
-    - "ftfy==6.1.1"
-    - "scipy==1.9.3"
-    - "transformers==4.25.1"
-    - "accelerate==0.15.0"
+  python_requirements: "requirements.txt"
 
 predict: "predict.py:Predictor"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+diffusers==0.11.1
+torch==1.13.0
+ftfy==6.1.1
+scipy==1.9.3
+transformers==4.25.1
+accelerate==0.15.0


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that `cog push`es the latest changes to https://replicate.com/stability-ai/stable-diffusion whenever a change lands on the main branch.

We may eventually want some checks in place to more selectively publish when certain conditions are met, but this seems like a good place to start, just to get something working.

## To Do

- [x] Ensure @zeke is in the @stability-ai org on Replicate
- [x] Add `REPLICATE_API_TOKEN` to repo secrets
- [ ] Test the workflow on a [forked repo](https://github.com/zeke/cog-stable-diffusion) and [forked model](https://replicate.com/zeke/stable-diffusion)
- [ ] Update the workflow file to publish to stability-ai/stable-diffusion (instead of zeke/stable-diffusion)
- [ ] Get review from the team
- [ ] Merge this PR 🤞