### PR TITLE
Add input to specify PNG, JPEG, or WebP output formats

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -10,6 +10,5 @@ build:
     - "transformers==4.25.1"
     - "accelerate==0.15.0"
     - "huggingface-hub==0.13.2"
-    - "werkzeug==2.3.4"
 
 predict: "predict.py:Predictor"

--- a/cog.yaml
+++ b/cog.yaml
@@ -10,5 +10,6 @@ build:
     - "transformers==4.25.1"
     - "accelerate==0.15.0"
     - "huggingface-hub==0.13.2"
+    - "werkzeug==2.3.4"
 
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -63,6 +63,11 @@ class Predictor(BasePredictor):
             description="Prompt strength when using init image. 1.0 corresponds to full destruction of information in init image",
             default=0.8,
         ),
+        format: str = Input(
+            description="Format of the output images",
+            choices=["png", "jpg", "webp"],
+            default="png",
+        ),
         num_outputs: int = Input(
             description="Number of images to output.",
             ge=1,
@@ -121,7 +126,7 @@ class Predictor(BasePredictor):
             if output.nsfw_content_detected and output.nsfw_content_detected[i]:
                 continue
 
-            output_path = f"/tmp/out-{i}.png"
+            output_path = f"/tmp/out-{i}.{format}"
             sample.save(output_path)
             output_paths.append(Path(output_path))
 

--- a/predict.py
+++ b/predict.py
@@ -15,6 +15,7 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
 )
+from werkzeug.utils import secure_filename
 
 # MODEL_ID refers to a diffusers-compatible model on HuggingFace
 # e.g. prompthero/openjourney-v2, wavymulder/Analog-Diffusion, etc
@@ -126,7 +127,8 @@ class Predictor(BasePredictor):
             if output.nsfw_content_detected and output.nsfw_content_detected[i]:
                 continue
 
-            output_path = f"/tmp/out-{i}.{format}"
+            filename = secure_filename(f"out-{i}.{format}")
+            output_path = os.path.join("/tmp", filename)
             sample.save(output_path)
             output_paths.append(Path(output_path))
 

--- a/predict.py
+++ b/predict.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import List
 
 import torch
@@ -15,7 +16,6 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
 )
-from werkzeug.utils import secure_filename
 
 # MODEL_ID refers to a diffusers-compatible model on HuggingFace
 # e.g. prompthero/openjourney-v2, wavymulder/Analog-Diffusion, etc
@@ -127,8 +127,8 @@ class Predictor(BasePredictor):
             if output.nsfw_content_detected and output.nsfw_content_detected[i]:
                 continue
 
-            filename = secure_filename(f"out-{i}.{format}")
-            output_path = os.path.join("/tmp", filename)
+            ext = re.sub(r'\W+', '', format)
+            output_path = os.path.join("/tmp", f"out-{i}.{ext}")
             sample.save(output_path)
             output_paths.append(Path(output_path))
 


### PR DESCRIPTION
Resolves #75 

Currently, predictions generate images in PNG format. This PR adds a new `format` input that allows predictions to generate JPEG and WebP formats instead. If unspecified, the PNG is used by default.