### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,7 +1,7 @@
 build:
   gpu: true
   cuda: "11.6"
-  python_version: "3.10"
+  python_version: "3.11.1"
   python_packages:
     - "diffusers==0.11.1"
     - "torch==1.13.0"


### PR DESCRIPTION
According to various sources [^1][^2], Python 3.11 offers something like 10% – 60% performance compared to Python 3.10 on certain benchmarks. I'm curious to see what effect it has on running Stable Diffusion.

[^1]: https://betterdatascience.com/python-310-vs-python-311/
[^2]: https://twitter.com/pypi/status/1603089763287826432