### PR TITLE
add Actions workflow to push to Replicate

### DIFF
--- a/.github/workflows/push-to-replicate.yaml
+++ b/.github/workflows/push-to-replicate.yaml
@@ -7,49 +7,51 @@ on:
     inputs:
       model_name:
         required: true
-        description: The name of the Replicate model to publish, in the format `username-or-org/modelname`.
+        description: "The name of the Replicate model to publish, e.g `username/modelname`. The model must already exist on Replicate."
 
 jobs:
   push_to_replicate:
-    # Custom organization runners with 64-cores, 256 GB RAM, 2040 GB SSD
-    runs-on: big-runner-for-zeke    
+    
+    # Custom runner with more CPU, memory, and disk than default runners
+    runs-on: ubuntu-latest-64-cores
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
 
-      # - name: Free disk space
-      #   uses: jlumbroso/free-disk-space@main
-      #   with:
-      #     large-packages: false
-      #     tool-cache: false
-
-      - name: Set up Docker Buildx
+      - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Install Cog and NVIDIA drivers
-        run: |
-          curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
+  
+      - name: Install NVIDIA CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.10
           
-      # This version of Cog adds support `cog run` on non-GPU environments like GitHub Actions' default runners
-      - name: Install Cog v0.8.0-beta3
+      # This version of Cog adds support for `cog run` on non-GPU environments (like GitHub Actions' default runners)
+      - name: Install Cog
         run: |
           sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/download/v0.8.0-beta3/cog_Linux_x86_64
           sudo chmod +x /usr/local/bin/cog
-          
-      - name: Print Docker and Cog version info
-        run: |
-          docker version
           cog --version
 
-      - name: Download model weights from HuggingFace
-        run: |
-          cog run script/download-weights
-  
       - name: Log in to Replicate
         env:
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
         run: |
           echo $REPLICATE_API_TOKEN | cog login --token-stdin
 
+      - name: Download model weights from HuggingFace
+        run: |
+          cog run script/download-weights
+
       - name: Push to Replicate
         run: |
           cog push r8.im/${{ inputs.model_name }}
+
+      - name: Open GitHub issue to notify users
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: 🚀 New version pushed to Replicate
+          body: |
+            Head's up: @${{ github.actor }} kicked off a workflow that pushed a new version of [${{ inputs.model_name }}](https://replicate.com/${{ inputs.model_name }}/versions) to Replicate!
+
+            Git commit: [${{ github.sha }}](https://github.com/${{github.repository}}/commit/${{github.sha}}).

--- a/.github/workflows/push-to-replicate.yaml
+++ b/.github/workflows/push-to-replicate.yaml
@@ -1,0 +1,55 @@
+name: Push model to Replicate
+
+# This workflow is triggered manually from the GitHub website.
+# To run it, click the "Actions" tab on the repo page.
+on:
+  workflow_dispatch:
+    inputs:
+      model_name:
+        required: true
+        description: The name of the Replicate model to publish, in the format `username-or-org/modelname`.
+
+jobs:
+  push_to_replicate:
+    # Custom organization runners with 64-cores, 256 GB RAM, 2040 GB SSD
+    runs-on: big-runner-for-zeke    
+    steps:
+      - uses: actions/checkout@v3
+
+      # - name: Free disk space
+      #   uses: jlumbroso/free-disk-space@main
+      #   with:
+      #     large-packages: false
+      #     tool-cache: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Install Cog and NVIDIA drivers
+        run: |
+          curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
+          
+      # This version of Cog adds support `cog run` on non-GPU environments like GitHub Actions' default runners
+      - name: Install Cog v0.8.0-beta3
+        run: |
+          sudo curl -o /usr/local/bin/cog -L https://github.com/replicate/cog/releases/download/v0.8.0-beta3/cog_Linux_x86_64
+          sudo chmod +x /usr/local/bin/cog
+          
+      - name: Print Docker and Cog version info
+        run: |
+          docker version
+          cog --version
+
+      - name: Download model weights from HuggingFace
+        run: |
+          cog run script/download-weights
+  
+      - name: Log in to Replicate
+        env:
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+        run: |
+          echo $REPLICATE_API_TOKEN | cog login --token-stdin
+
+      - name: Push to Replicate
+        run: |
+          cog push r8.im/${{ inputs.model_name }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for pushing the model to Replicate. The workflow is triggered manually in the Actions tab.

- [x] Create a token for the @stability-ai org on Replicate
- [x] Add that token to this repo's secrets as `REPLICATE_API_TOKEN`
- [x] Test the workflow on a copy of this repo to confirm that it works (because [`workflow_dispatch` can only be used on a repo's default branch](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually))
- [ ] Get review from the team
- [ ] Merge this PR 🤞